### PR TITLE
add zones for popup and footer

### DIFF
--- a/app/src/main/java/jwtc/android/chess/main.java
+++ b/app/src/main/java/jwtc/android/chess/main.java
@@ -4,6 +4,7 @@ import jwtc.chess.*;
 
 import android.app.AlertDialog;
 import android.content.Context;
+import android.graphics.Color;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.net.Uri;
@@ -28,8 +29,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 
-import android.view.GestureDetector.OnGestureListener;
 import android.view.GestureDetector;
+import android.webkit.WebView;
 import android.widget.TextView;
 
 public class main extends ChessActivity implements OnInitListener, GestureDetector.OnGestureListener {
@@ -97,6 +98,17 @@ public class main extends ChessActivity implements OnInitListener, GestureDetect
         _dlgSave = null;
 
         _gestureDetector = new GestureDetector(this, this);
+
+        AlertDialog.Builder zone1 = new AlertDialog.Builder(this);
+        WebView webView = new WebView(this);
+        webView.loadUrl("https://static.ironsrc.com/wp-content/uploads/2017/12/Untitled-presentation-4.png");
+        zone1.setView(webView);
+        zone1.show();
+
+        WebView zone2 = (WebView) findViewById(R.id.SnapyrZone2);
+        zone2.loadUrl("https://static.ironsrc.com/wp-content/uploads/2017/12/Untitled-presentation-3.png");
+        zone2.setBackgroundColor(Color.TRANSPARENT);
+        zone2.setLayerType(WebView.LAYER_TYPE_SOFTWARE, null);
     }
 
     @Override

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -206,7 +206,9 @@
 				    android:layout_width="wrap_content"
 				    android:layout_height="wrap_content"
 				/>
+
 			</HorizontalScrollView>
+
 			
 			<ScrollView android:layout_width="fill_parent" android:layout_height="wrap_content"
 				android:fadingEdge="none" android:padding="2dip"
@@ -231,6 +233,7 @@
 						android:layout_width="72dip" android:layout_height="40dip"
 					/>
 				</TableRow>
+
 			</TableLayout>
 			
 			<TableLayout android:layout_width="fill_parent" android:layout_height="wrap_content"
@@ -250,7 +253,16 @@
 			</TableLayout>	
 			
 		</ViewAnimator>
-		
 	</RelativeLayout>
-	
+	<RelativeLayout
+		android:layout_width= "match_parent"
+		android:layout_height= "match_parent"
+		android:orientation= "vertical">
+		<WebView
+			android:id="@+id/SnapyrZone2"
+			android:layout_width= "wrap_content"
+			android:layout_height= "wrap_content"
+			android:layout_alignParentBottom= "true"
+			android:layout_centerHorizontal="true" />
+	</RelativeLayout>
 </RelativeLayout>


### PR DESCRIPTION
Little code to show for the amount of trial and error I went through.

AlertDialog.builder can be instantiated from within an Activity, or at least requires an Activity context if instantiated elsewhere.

I had tried to open connections directly to the URL, which android only allows from within threads/asynctask and not in the main thread.  Fortunately that was a rabbit trail since WebView has a loadUrl method that does it all.

For the footer, I added a RelativeLayout with a WebView positioned at the bottom.  I've tried a bunch of things to center it horizontally with no luck.  Hopefully that can be done from the html to be displayed.

I originally put this code in start.java, where the Analytics is created.  But I could not load the zone2 WebView from there since it's not shown yet.  I moved it all to main.java, which is the main game not the main thread, and it works.  I wasn't sure if you wanted to put all of that directly inside of SnapyrSdk or if it will provide a way to register handlers of some sort.  